### PR TITLE
Use get_pid method instead of try-except

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -150,14 +150,7 @@ class Daemon(object):
         self.log("Starting...")
 
         # Check for a pidfile to see if the daemon already runs
-        try:
-            pf = open(self.pidfile, 'r')
-            pid = int(pf.read().strip())
-            pf.close()
-        except IOError:
-            pid = None
-        except SystemExit:
-            pid = None
+        pid = self.get_pid()
 
         if pid:
             message = "pidfile %s already exists. Is it already running?\n"


### PR DESCRIPTION
Use `get_pid` method inside `start` method instead of try-except section.